### PR TITLE
[MOBILE-1190] Wait for Airship Ready before updating device attributes

### DIFF
--- a/ios/UARCTGimbalAdapter/UAGimbalAdapter.m
+++ b/ios/UARCTGimbalAdapter/UAGimbalAdapter.m
@@ -21,20 +21,22 @@ NSString *const GimbalSource = @"Gimbal";
 // NSUserDefault Keys
 NSString *const GimbalAlertViewKey = @"gmbl_hide_bt_power_alert_view";
 
+NSString * const UAAirshipReadyNotification = @"com.urbanairship.airship_ready";
+
 @implementation UAGimbalAdapter
 
 static id _sharedObject = nil;
 
 + (void)load {
     [[NSNotificationCenter defaultCenter] addObserver:[UAGimbalAdapter class]
-                                             selector:@selector(handleAppDidFinishLaunching)
-                                                 name:UIApplicationDidFinishLaunchingNotification
+                                             selector:@selector(handleAirshipReady)
+                                                 name:UAAirshipReadyNotification
                                                object:nil];
 }
 
-+ (void)handleAppDidFinishLaunching {
++ (void)handleAirshipReady {
     [[NSNotificationCenter defaultCenter] removeObserver:[UAGimbalAdapter class]
-                                                    name:UIApplicationDidFinishLaunchingNotification
+                                                    name:UAAirshipReadyNotification
                                                   object:nil];
 
     [[UAGimbalAdapter shared] updateDeviceAttributes];
@@ -52,8 +54,8 @@ static id _sharedObject = nil;
     self = [super init];
     if (self) {
         self.placeManager = [[GMBLPlaceManager alloc] init];
-        self.deviceAttributesManager = [GMBLDeviceAttributesManager new];
         self.placeManager.delegate = self;
+        self.deviceAttributesManager = [GMBLDeviceAttributesManager new];
 
         // Hide the power alert by default
         if (![[NSUserDefaults standardUserDefaults] valueForKey:GimbalAlertViewKey]) {
@@ -84,7 +86,7 @@ static id _sharedObject = nil;
 
 - (void)startWithGimbalAPIKey:(NSString *)gimbalAPIKey {
     [Gimbal setAPIKey:gimbalAPIKey options:nil];
-    [Gimbal start];
+    [GMBLPlaceManager startMonitoring];
     [self updateDeviceAttributes];
     UA_LDEBUG(@"Started Gimbal Adapter. Gimbal application instance identifier: %@", [Gimbal applicationInstanceIdentifier]);
 }
@@ -110,7 +112,7 @@ static id _sharedObject = nil;
 }
 
 - (void)stop {
-    [Gimbal stop];
+    [GMBLPlaceManager stopMonitoring];
     UA_LDEBUG(@"Stopped Gimbal Adapter.");
 }
 

--- a/ios/UARCTGimbalAdapter/UAGimbalAdapter.m
+++ b/ios/UARCTGimbalAdapter/UAGimbalAdapter.m
@@ -55,7 +55,7 @@ static id _sharedObject = nil;
     if (self) {
         self.placeManager = [[GMBLPlaceManager alloc] init];
         self.placeManager.delegate = self;
-        self.deviceAttributesManager = [GMBLDeviceAttributesManager new];
+        self.deviceAttributesManager = [[GMBLDeviceAttributesManager alloc] init];
 
         // Hide the power alert by default
         if (![[NSUserDefaults standardUserDefaults] valueForKey:GimbalAlertViewKey]) {

--- a/ios/UARCTGimbalAdapter/UAGimbalAdapter.m
+++ b/ios/UARCTGimbalAdapter/UAGimbalAdapter.m
@@ -86,7 +86,7 @@ static id _sharedObject = nil;
 
 - (void)startWithGimbalAPIKey:(NSString *)gimbalAPIKey {
     [Gimbal setAPIKey:gimbalAPIKey options:nil];
-    [GMBLPlaceManager startMonitoring];
+    [Gimbal start];
     [self updateDeviceAttributes];
     UA_LDEBUG(@"Started Gimbal Adapter. Gimbal application instance identifier: %@", [Gimbal applicationInstanceIdentifier]);
 }
@@ -112,7 +112,7 @@ static id _sharedObject = nil;
 }
 
 - (void)stop {
-    [GMBLPlaceManager stopMonitoring];
+    [Gimbal stop];
     UA_LDEBUG(@"Stopped Gimbal Adapter.");
 }
 


### PR DESCRIPTION
I wasn't getting any region events when testing. On further review, I found what I thought were 2 problems:
1. Start and Stop weren't implemented the same way as the current Goat plugin.
2. `updateDeviceAttributes` needed Airship to be ready before it is called. 

After fixing those two things, I started seeing region events being sent from our SDK as they should be.

Update: It must have been some other change that caused region events to start working. I think maybe Gimbal's backend and our backend have some delays and are sensitive to configuration. I reverted my first change. I am still receiving region enter and exit events, and have built automations that successfully send pushes when those events are received.

Should be good to go with the remaining minor change.